### PR TITLE
Add hidden DonCiccio subpages with nested routes

### DIFF
--- a/DonCiccio/Amarolineup/index.html
+++ b/DonCiccio/Amarolineup/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Don Ciccio - Amaro Lineup</title>
+  <meta name="robots" content="noindex, nofollow">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; line-height: 1.5; }
+  </style>
+</head>
+<body>
+  <h1>Amaro Lineup</h1>
+  <p>Placeholder page ready for your provided <code>index.html</code>.</p>
+  <p><a href="/DonCiccio/">Back to DonCiccio</a></p>
+</body>
+</html>

--- a/DonCiccio/cocktailrecipes/index.html
+++ b/DonCiccio/cocktailrecipes/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Don Ciccio - Cocktail Recipes</title>
+  <meta name="robots" content="noindex, nofollow">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; line-height: 1.5; }
+  </style>
+</head>
+<body>
+  <h1>Cocktail Recipes</h1>
+  <p>Placeholder page ready for your provided <code>index.html</code>.</p>
+  <p><a href="/DonCiccio/">Back to DonCiccio</a></p>
+</body>
+</html>

--- a/DonCiccio/index.html
+++ b/DonCiccio/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Don Ciccio</title>
+  <meta name="robots" content="noindex, nofollow">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; line-height: 1.5; }
+    h1 { margin-bottom: 0.5rem; }
+    ul { margin-top: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Don Ciccio</h1>
+  <p>This subpage is set up and ready for your final HTML content.</p>
+  <p>Links:</p>
+  <ul>
+    <li><a href="/DonCiccio/cocktailrecipes/">cocktailrecipes</a></li>
+    <li><a href="/DonCiccio/Amarolineup/">Amarolineup</a></li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a small, hidden section of the site at `/DonCiccio/` with two nested routes to allow dropping in final HTML pages without exposing them in search engines.
- Keep the pages unindexed by default so they remain discoverable only by direct URL.

### Description
- Added `DonCiccio/index.html` as a top-level hidden subpage that links to the nested routes `cocktailrecipes` and `Amarolineup`.
- Added placeholder pages at `DonCiccio/cocktailrecipes/index.html` and `DonCiccio/Amarolineup/index.html` ready to be replaced with the user's provided `index.html` files.
- Each new page includes a `<meta name="robots" content="noindex, nofollow">` tag to prevent indexing.
- Simple placeholder content and internal back links were added so the subpages are navigable immediately.

### Testing
- Verified files exist with `rg --files DonCiccio` and the file listing returned the three new paths (succeeded).
- Inspected the created files with `nl` to confirm the placeholder HTML and the presence of the `noindex, nofollow` meta tag in each file (succeeded).
- Confirmed the repository recorded the change via a repository state check (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7fc9e1d708325bb467965305fc5bf)